### PR TITLE
Escape '$' when launching Scalpel

### DIFF
--- a/plugin/scalpel.vim
+++ b/plugin/scalpel.vim
@@ -304,10 +304,10 @@ endfunction
 " Change all instances of current word (mnemonic: edit).
 execute 'nnoremap <Plug>(Scalpel) :' .
       \ s:command .
-      \ "/\\v<<C-R>=expand('<cword>')<CR>>//<Left>"
+      \ "/\\v<<C-R>=escape(expand('<cword>'), '$')<CR>>//<Left>"
 execute 'vnoremap <Plug>(ScalpelVisual) :' .
       \ s:command .
-      \ "/\\v<<C-R>=scalpel#cword(<SID>GetCurpos())<CR>>//<Left>"
+      \ "/\\v<<C-R>=escape(scalpel#cword(<SID>GetCurpos()), '$')<CR>>//<Left>"
 
 let s:map=get(g:, 'ScalpelMap', 1)
 if s:map


### PR DESCRIPTION
Fixes #10 

I've decided to only escape `$` as I can't think of any other special characters where this is useful. However, this can easily expanded to include other characters.